### PR TITLE
Add function to generate configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 # Empty directory that contains temporary files
-*
-!.gitignore
 example/mocks/util1/util1
 example/mocks/util2/util2

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ test-bldmock: bldmock
 genrconfig: bldmock
 	go build -o cmd/genrconfig/genrconfig github.com/googleinterns/executable-mocks/cmd/genrconfig/
 
+test-genrconfig: genrconfig
+	mkdir -p tmp/
+	bash test/genrconfig_test.sh
+
 clean:
 	rm -rf examples/mocks/util2/util2
 	rm -rf examples/mocks/util1/util1

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ifndef $(GOPATH)
     export GOPATH
 endif
 
-all: mocks hash test-mockexec test-bldmock
+all: mocks hash test-mockexec test-bldmock genrconfig
 
 util2:
 	go build -o examples/mocks/util2/util2 github.com/googleinterns/executable-mocks/examples/mocks/util2
@@ -44,10 +44,13 @@ test-mockexec: mockexec
 	bash test/mockexec_test.sh
 
 bldmock: proto
-	go build -o cmd/bldmock/bldmock github.com/regb/executable-mocks/cmd/bldmock/
+	go build -o cmd/bldmock/bldmock github.com/googleinterns/executable-mocks/cmd/bldmock/
 
 test-bldmock: bldmock
 	go run test/bldmocktest.go
+
+genrconfig: bldmock
+	go build -o cmd/genrconfig/genrconfig github.com/googleinterns/executable-mocks/cmd/genrconfig/
 
 clean:
 	rm -rf examples/mocks/util2/util2
@@ -57,5 +60,6 @@ clean:
 	rm -rf tmp/*
 	rm -rf cmd/mockexec/mockexec
 	rm -rf cmd/bldmock/bldmock
+	rm -rf cmd/genrconfig/genrconfig
 
-.PHONY: all util2 util1 mocks hash proto mockexec test-mockexec bldmock test-bldmock clean
+.PHONY: all util2 util1 mocks hash proto mockexec test-mockexec bldmock test-bldmock genrconfig clean

--- a/Makefile
+++ b/Makefile
@@ -66,4 +66,4 @@ clean:
 	rm -rf cmd/bldmock/bldmock
 	rm -rf cmd/genrconfig/genrconfig
 
-.PHONY: all util2 util1 mocks hash proto mockexec test-mockexec bldmock test-bldmock genrconfig clean
+.PHONY: all util2 util1 mocks hash proto mockexec test-mockexec bldmock test-bldmock genrconfig test-genrconfig clean

--- a/cmd/bldmock/bldmock.go
+++ b/cmd/bldmock/bldmock.go
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package bldmock
 
 import (
@@ -7,7 +22,7 @@ import (
   "io"
   "fmt"
   
-  pb "github.com/regb/executable-mocks/protos/mockexec"
+  pb "github.com/googleinterns/executable-mocks/protos/mockexec"
 )
 
 type StrArg string

--- a/cmd/genrconfig/main.go
+++ b/cmd/genrconfig/main.go
@@ -28,18 +28,16 @@ import (
 
 /*
  * Takes command line arguments and generates a Protocol Buffer configuration file.
- * An example of use is: ./genrconfig configs/example name "strarg:generic string" "infile:tmp/input"
- * The first argument defines the path of the configuration file. The extension .textproto is added.
- * In the example, the configuration file path would be "configs/example.textproto".
- * The second argument is the name of the binary and the arguments follow.
+ * An example of use is: ./genrconfig binary "strarg:generic string" "infile:tmp/input"
+ * The second argudment is the name of the binary and the arguments follow.
  * The arguments must have as a prefix "type:". The type can be: strarg, infile, outpath, outcontent.
  */
 func main() {
-  if len(os.Args) < 3 {
-    log.Fatal("Expected the configuration file path and the name of the binary.")
+  if len(os.Args) < 2 {
+    log.Fatal("Expected the name of the binary.")
   }
   args := []interface{} {}
-  for i := 3; i < len(os.Args); i++ {
+  for i := 2; i < len(os.Args); i++ {
     if (strings.HasPrefix(os.Args[i], "strarg:")) {
       args = append(args, bldmock.StrArg(strings.TrimPrefix(os.Args[i], "strarg:")))
     } else if (strings.HasPrefix(os.Args[i], "infile:")) {
@@ -52,8 +50,8 @@ func main() {
       log.Fatalf("Unexpected argument: %s has an unknown prefix.", os.Args[i])
     }
   }
-  mc := bldmock.BuildMockConfig(os.Args[2], args...)
-  if err := ioutil.WriteFile(fmt.Sprintf("%s.textproto", os.Args[1]), []byte(proto.MarshalTextString(&mc)), 0700); err != nil {
+  mc := bldmock.BuildMockConfig(os.Args[1], args...)
+  if _, err := fmt.Print([]byte(proto.MarshalTextString(&mc))); err != nil {
       log.Fatal(err)
   }
 }

--- a/cmd/genrconfig/main.go
+++ b/cmd/genrconfig/main.go
@@ -19,7 +19,6 @@ import (
   "os"
   "fmt"
   "log"
-  "io/ioutil"
   "strings"
   
   "github.com/googleinterns/executable-mocks/cmd/bldmock"
@@ -51,7 +50,7 @@ func main() {
     }
   }
   mc := bldmock.BuildMockConfig(os.Args[1], args...)
-  if _, err := fmt.Print([]byte(proto.MarshalTextString(&mc))); err != nil {
+  if _, err := fmt.Print((proto.MarshalTextString(&mc))); err != nil {
       log.Fatal(err)
   }
 }

--- a/cmd/genrconfig/main.go
+++ b/cmd/genrconfig/main.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package main
+
+import (
+  "os"
+  "fmt"
+  "log"
+  "io/ioutil"
+  "strings"
+  
+  "github.com/googleinterns/executable-mocks/cmd/bldmock"
+  "github.com/golang/protobuf/proto"
+)
+
+/*
+ * Takes command line arguments and generates a Protocol Buffer configuration file.
+ * An example of use is: ./genrconfig configs/example name "strarg:generic string" "infile:tmp/input"
+ * The first argument defines the path of the configuration file. The extension .textproto is added.
+ * In the example, the configuration file path would be "configs/example.textproto".
+ * The second argument is the name of the binary and the arguments follow.
+ * The arguments must have as a prefix "type:". The type can be: strarg, infile, outpath, outcontent.
+ */
+func main() {
+  if len(os.Args) < 3 {
+    log.Fatal("Expected the configuration file path and the name of the binary.")
+  }
+  args := []interface{} {}
+  for i := 3; i < len(os.Args); i++ {
+    if (strings.HasPrefix(os.Args[i], "strarg:")) {
+      args = append(args, bldmock.StrArg(strings.TrimPrefix(os.Args[i], "strarg:")))
+    } else if (strings.HasPrefix(os.Args[i], "infile:")) {
+      args = append(args, bldmock.InFile(strings.TrimPrefix(os.Args[i], "infile:")))
+    } else if (strings.HasPrefix(os.Args[i], "outpath:")) {
+      args = append(args, bldmock.OutPath(strings.TrimPrefix(os.Args[i], "outpath:")))
+    } else if (strings.HasPrefix(os.Args[i], "outcontent:")) {
+      args = append(args, bldmock.OutContent(strings.TrimPrefix(os.Args[i], "outcontent:")))
+    } else {
+      log.Fatalf("Unexpected argument: %s has an unknown prefix.", os.Args[i])
+    }
+  }
+  mc := bldmock.BuildMockConfig(os.Args[2], args...)
+  if err := ioutil.WriteFile(fmt.Sprintf("%s.textproto", os.Args[1]), []byte(proto.MarshalTextString(&mc)), 0700); err != nil {
+      log.Fatal(err)
+  }
+}

--- a/protos/mockexec.proto
+++ b/protos/mockexec.proto
@@ -15,7 +15,7 @@
 syntax = "proto3";
 package mockexec;
 
-option go_package = "github.com/regb/executable-mocks/protos/mockexec";
+option go_package = "github.com/googleinterns/executable-mocks/protos/mockexec";
 
 // Argument represents a single command line argument.
 message Argument {

--- a/test/genrconfig_test.sh
+++ b/test/genrconfig_test.sh
@@ -24,7 +24,7 @@ EXIT_STATUS=0
 echo "INPUT1" > tmp/test-input1
 echo "INPUT2" > tmp/test-input2
 cmd/genrconfig/genrconfig tar "strarg:-cf" "outpath:tmp/output" "infile:tmp/test-input1" "infile:tmp/test-input2" > tmp/tar.textproto
-if [ $? -ne 0 ] || [ ! -f "tmp/tar.textproto" ] || [ "$(cmp -s "test/testdata/testgenrconfig.textproto" "tmp/tar.textproto")" == "1" ]
+if [ $? -ne 0 ] || [ ! -f "tmp/tar.textproto" ] || [[ $(cmp -s "test/testdata/testgenrconfig.textproto" "tmp/tar.textproto") -ne 0 ]]
 then
 	echo "Test 1: not working properly."
 	EXIT_STATUS=1
@@ -34,7 +34,7 @@ fi
 echo "INPUT1" > tmp/test-input1
 echo "INPUT2" > tmp/test-input2
 cmd/genrconfig/genrconfig tar "strarg:-cf" "outcontent:OUTPUT" "infile:tmp/test-input1" "infile:tmp/test-input2" > tmp/tar.textproto
-if [ $? -ne 0 ] || [ ! -f "tmp/tar.textproto" ] || [ "$(cmp -s "test/testdata/testgenrconfig.textproto" "tmp/tar.textproto")" == "1" ]
+if [ $? -ne 0 ] || [ ! -f "tmp/tar.textproto" ] || [[ $(cmp -s "test/testdata/testgenrconfig.textproto" "tmp/tar.textproto") -ne 0 ]]
 then
 	echo "Test 2: not working properly."
 	EXIT_STATUS=1

--- a/test/genrconfig_test.sh
+++ b/test/genrconfig_test.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# mockexec_test.sh exercises the mock executable and verifies that it behaves as expected.
+# It takes no inputs from commandline, prints issues to stdout and returns a non-zero
+# exit status when expectations are not met.
+
+EXIT_STATUS=0
+
+# correct usage testcase 1 (with output path)
+echo "INPUT1" > tmp/test-input1
+echo "INPUT2" > tmp/test-input2
+cmd/genrconfig/genrconfig examples/tar tar "strarg:-cf" "outpath:tmp/output" "infile:tmp/test-input1" "infile:tmp/test-input2" > /dev/null 2>&1
+if [ $? -ne 0 ]
+then
+	echo "Test 1: not working properly."
+	EXIT_STATUS=1
+fi
+
+# correct usage testcase 2 (with output content)
+echo "INPUT1" > tmp/test-input1
+echo "INPUT2" > tmp/test-input2
+cmd/genrconfig/genrconfig examples/tar tar "strarg:-cf" "outcontent:OUTPUT" "infile:tmp/test-input1" "infile:tmp/test-input2" > /dev/null 2>&1
+if [ $? -ne 0 ]
+then
+	echo "Test 2: not working properly."
+	EXIT_STATUS=1
+fi
+
+# incorrect usage testcase 3 (not enough arguments)
+echo "INPUT" > tmp/test-input
+cmd/genrconfig/genrconfig "strarg:-cf" > /dev/null 2>&1
+if [ $? -eq 0 ]
+then
+	echo "Test 3: not working properly."
+	EXIT_STATUS=1
+fi
+
+# incorrect usage testcase 4 (unknown type of argument)
+echo "INPUT" > tmp/test-input
+cmd/genrconfig/genrconfig examples/tar tar "strarg:-cf" "outpath:tmp/output" "inhash:4cb90a97dd7fc70b16eeefa5c3937769b7a35d7ba1a07db400b8d470dacbf030" > /dev/null 2>&1
+if [ $? -eq 0 ]
+then
+	echo "Test 4: not working properly."
+	EXIT_STATUS=1
+fi

--- a/test/genrconfig_test.sh
+++ b/test/genrconfig_test.sh
@@ -23,7 +23,7 @@ EXIT_STATUS=0
 # correct usage testcase 1 (with output path)
 echo "INPUT1" > tmp/test-input1
 echo "INPUT2" > tmp/test-input2
-cmd/genrconfig/genrconfig tar "strarg:-cf" "outpath:tmp/output" "infile:tmp/test-input1" "infile:tmp/test-input2" > examples/tar
+cmd/genrconfig/genrconfig tar "strarg:-cf" "outpath:tmp/output" "infile:tmp/test-input1" "infile:tmp/test-input2" > examples/tar.textproto
 if [ $? -ne 0 ]
 then
 	echo "Test 1: not working properly."
@@ -33,7 +33,7 @@ fi
 # correct usage testcase 2 (with output content)
 echo "INPUT1" > tmp/test-input1
 echo "INPUT2" > tmp/test-input2
-cmd/genrconfig/genrconfig tar "strarg:-cf" "outcontent:OUTPUT" "infile:tmp/test-input1" "infile:tmp/test-input2" > examples/tar
+cmd/genrconfig/genrconfig tar "strarg:-cf" "outcontent:OUTPUT" "infile:tmp/test-input1" "infile:tmp/test-input2" > examples/tar.textproto
 if [ $? -ne 0 ]
 then
 	echo "Test 2: not working properly."
@@ -42,7 +42,7 @@ fi
 
 # incorrect usage testcase 3 (not enough arguments)
 echo "INPUT" > tmp/test-input
-cmd/genrconfig/genrconfig "strarg:-cf" > examples/tar
+cmd/genrconfig/genrconfig "strarg:-cf" > examples/tar.textproto
 if [ $? -eq 0 ]
 then
 	echo "Test 3: not working properly."
@@ -51,7 +51,7 @@ fi
 
 # incorrect usage testcase 4 (unknown type of argument)
 echo "INPUT" > tmp/test-input
-cmd/genrconfig/genrconfig tar "strarg:-cf" "outpath:tmp/output" "inhash:4cb90a97dd7fc70b16eeefa5c3937769b7a35d7ba1a07db400b8d470dacbf030" > examples/tar
+cmd/genrconfig/genrconfig tar "strarg:-cf" "outpath:tmp/output" "inhash:4cb90a97dd7fc70b16eeefa5c3937769b7a35d7ba1a07db400b8d470dacbf030" > examples/tar.textproto
 if [ $? -eq 0 ]
 then
 	echo "Test 4: not working properly."

--- a/test/genrconfig_test.sh
+++ b/test/genrconfig_test.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# mockexec_test.sh exercises the mock executable and verifies that it behaves as expected.
+# genrconfig_test.sh exercises the generate configuration file function and verifies that it behaves as expected.
 # It takes no inputs from commandline, prints issues to stdout and returns a non-zero
 # exit status when expectations are not met.
 
@@ -23,7 +23,7 @@ EXIT_STATUS=0
 # correct usage testcase 1 (with output path)
 echo "INPUT1" > tmp/test-input1
 echo "INPUT2" > tmp/test-input2
-cmd/genrconfig/genrconfig examples/tar tar "strarg:-cf" "outpath:tmp/output" "infile:tmp/test-input1" "infile:tmp/test-input2" > /dev/null 2>&1
+cmd/genrconfig/genrconfig tar "strarg:-cf" "outpath:tmp/output" "infile:tmp/test-input1" "infile:tmp/test-input2" > examples/tar
 if [ $? -ne 0 ]
 then
 	echo "Test 1: not working properly."
@@ -33,7 +33,7 @@ fi
 # correct usage testcase 2 (with output content)
 echo "INPUT1" > tmp/test-input1
 echo "INPUT2" > tmp/test-input2
-cmd/genrconfig/genrconfig examples/tar tar "strarg:-cf" "outcontent:OUTPUT" "infile:tmp/test-input1" "infile:tmp/test-input2" > /dev/null 2>&1
+cmd/genrconfig/genrconfig tar "strarg:-cf" "outcontent:OUTPUT" "infile:tmp/test-input1" "infile:tmp/test-input2" > examples/tar
 if [ $? -ne 0 ]
 then
 	echo "Test 2: not working properly."
@@ -42,7 +42,7 @@ fi
 
 # incorrect usage testcase 3 (not enough arguments)
 echo "INPUT" > tmp/test-input
-cmd/genrconfig/genrconfig "strarg:-cf" > /dev/null 2>&1
+cmd/genrconfig/genrconfig "strarg:-cf" > examples/tar
 if [ $? -eq 0 ]
 then
 	echo "Test 3: not working properly."
@@ -51,7 +51,7 @@ fi
 
 # incorrect usage testcase 4 (unknown type of argument)
 echo "INPUT" > tmp/test-input
-cmd/genrconfig/genrconfig examples/tar tar "strarg:-cf" "outpath:tmp/output" "inhash:4cb90a97dd7fc70b16eeefa5c3937769b7a35d7ba1a07db400b8d470dacbf030" > /dev/null 2>&1
+cmd/genrconfig/genrconfig tar "strarg:-cf" "outpath:tmp/output" "inhash:4cb90a97dd7fc70b16eeefa5c3937769b7a35d7ba1a07db400b8d470dacbf030" > examples/tar
 if [ $? -eq 0 ]
 then
 	echo "Test 4: not working properly."

--- a/test/genrconfig_test.sh
+++ b/test/genrconfig_test.sh
@@ -23,8 +23,8 @@ EXIT_STATUS=0
 # correct usage testcase 1 (with output path)
 echo "INPUT1" > tmp/test-input1
 echo "INPUT2" > tmp/test-input2
-cmd/genrconfig/genrconfig tar "strarg:-cf" "outpath:tmp/output" "infile:tmp/test-input1" "infile:tmp/test-input2" > examples/tar.textproto
-if [ $? -ne 0 ]
+cmd/genrconfig/genrconfig tar "strarg:-cf" "outpath:tmp/output" "infile:tmp/test-input1" "infile:tmp/test-input2" > tmp/tar.textproto
+if [ $? -ne 0 ] || [ ! -f "tmp/tar.textproto" ] || [ "$(cmp -s "test/testdata/testgenrconfig.textproto" "tmp/tar.textproto")" == "1" ]
 then
 	echo "Test 1: not working properly."
 	EXIT_STATUS=1
@@ -33,8 +33,8 @@ fi
 # correct usage testcase 2 (with output content)
 echo "INPUT1" > tmp/test-input1
 echo "INPUT2" > tmp/test-input2
-cmd/genrconfig/genrconfig tar "strarg:-cf" "outcontent:OUTPUT" "infile:tmp/test-input1" "infile:tmp/test-input2" > examples/tar.textproto
-if [ $? -ne 0 ]
+cmd/genrconfig/genrconfig tar "strarg:-cf" "outcontent:OUTPUT" "infile:tmp/test-input1" "infile:tmp/test-input2" > tmp/tar.textproto
+if [ $? -ne 0 ] || [ ! -f "tmp/tar.textproto" ] || [ "$(cmp -s "test/testdata/testgenrconfig.textproto" "tmp/tar.textproto")" == "1" ]
 then
 	echo "Test 2: not working properly."
 	EXIT_STATUS=1
@@ -42,7 +42,7 @@ fi
 
 # incorrect usage testcase 3 (not enough arguments)
 echo "INPUT" > tmp/test-input
-cmd/genrconfig/genrconfig "strarg:-cf" > examples/tar.textproto
+cmd/genrconfig/genrconfig "strarg:-cf" > tmp/tar.textproto
 if [ $? -eq 0 ]
 then
 	echo "Test 3: not working properly."
@@ -51,7 +51,7 @@ fi
 
 # incorrect usage testcase 4 (unknown type of argument)
 echo "INPUT" > tmp/test-input
-cmd/genrconfig/genrconfig tar "strarg:-cf" "outpath:tmp/output" "inhash:4cb90a97dd7fc70b16eeefa5c3937769b7a35d7ba1a07db400b8d470dacbf030" > examples/tar.textproto
+cmd/genrconfig/genrconfig tar "strarg:-cf" "outpath:tmp/output" "inhash:4cb90a97dd7fc70b16eeefa5c3937769b7a35d7ba1a07db400b8d470dacbf030" > tmp/tar.textproto
 if [ $? -eq 0 ]
 then
 	echo "Test 4: not working properly."

--- a/test/genrconfig_test.sh
+++ b/test/genrconfig_test.sh
@@ -23,8 +23,8 @@ EXIT_STATUS=0
 # correct usage testcase 1 (with output path)
 echo "INPUT1" > tmp/test-input1
 echo "INPUT2" > tmp/test-input2
-cmd/genrconfig/genrconfig tar "strarg:-cf" "outpath:tmp/output" "infile:tmp/test-input1" "infile:tmp/test-input2" > tmp/tar.textproto
-if [ $? -ne 0 ] || [ ! -f "tmp/tar.textproto" ] || [[ $(cmp -s "test/testdata/testgenrconfig.textproto" "tmp/tar.textproto") -ne 0 ]]
+cmd/genrconfig/genrconfig tar "strarg:-cf" "outpath:tmp/test-output" "infile:tmp/test-input1" "infile:tmp/test-input2" > tmp/tar.textproto 2>&1
+if [ $? -ne 0 ] || [ ! -f "tmp/tar.textproto" ] || [ $(cmp -s "test/testdata/testgenrconfig1.textproto" "tmp/tar.textproto")$? -ne 0 ]
 then
 	echo "Test 1: not working properly."
 	EXIT_STATUS=1
@@ -33,8 +33,8 @@ fi
 # correct usage testcase 2 (with output content)
 echo "INPUT1" > tmp/test-input1
 echo "INPUT2" > tmp/test-input2
-cmd/genrconfig/genrconfig tar "strarg:-cf" "outcontent:OUTPUT" "infile:tmp/test-input1" "infile:tmp/test-input2" > tmp/tar.textproto
-if [ $? -ne 0 ] || [ ! -f "tmp/tar.textproto" ] || [[ $(cmp -s "test/testdata/testgenrconfig.textproto" "tmp/tar.textproto") -ne 0 ]]
+cmd/genrconfig/genrconfig tar "strarg:-cf" "outcontent:OUTPUT" "infile:tmp/test-input1" "infile:tmp/test-input2" > tmp/tar.textproto 2>&1
+if [ $? -ne 0 ] || [ ! -f "tmp/tar.textproto" ] || [ $(cmp -s "test/testdata/testgenrconfig2.textproto" "tmp/tar.textproto")$? -ne 0 ]
 then
 	echo "Test 2: not working properly."
 	EXIT_STATUS=1
@@ -42,7 +42,7 @@ fi
 
 # incorrect usage testcase 3 (not enough arguments)
 echo "INPUT" > tmp/test-input
-cmd/genrconfig/genrconfig "strarg:-cf" > tmp/tar.textproto
+cmd/genrconfig/genrconfig > tmp/tar.textproto 2>&1
 if [ $? -eq 0 ]
 then
 	echo "Test 3: not working properly."
@@ -51,7 +51,7 @@ fi
 
 # incorrect usage testcase 4 (unknown type of argument)
 echo "INPUT" > tmp/test-input
-cmd/genrconfig/genrconfig tar "strarg:-cf" "outpath:tmp/output" "inhash:4cb90a97dd7fc70b16eeefa5c3937769b7a35d7ba1a07db400b8d470dacbf030" > tmp/tar.textproto
+cmd/genrconfig/genrconfig tar "strarg:-cf" "outpath:tmp/output" "inhash:4cb90a97dd7fc70b16eeefa5c3937769b7a35d7ba1a07db400b8d470dacbf030" > tmp/tar.textproto 2>&1
 if [ $? -eq 0 ]
 then
 	echo "Test 4: not working properly."

--- a/test/testdata/testgenrconfig.textproto
+++ b/test/testdata/testgenrconfig.textproto
@@ -1,0 +1,13 @@
+binary: "tar"
+args: <
+  str_arg: "-cf"
+>
+args: <
+  out_path: "tmp/output"
+>
+args: <
+  in_hash: "5450a4acb852ff4521aed7ee121c41e4e7388828714f93623807f12b14e3e4cc"
+>
+args: <
+  in_hash: "2590532ed6ac4e4552dc68b26cfe7888480d185a8bf7152c92bb6f0f20571ea5"
+>

--- a/test/testdata/testgenrconfig1.textproto
+++ b/test/testdata/testgenrconfig1.textproto
@@ -1,0 +1,13 @@
+binary: "tar"
+args: <
+  str_arg: "-cf"
+>
+args: <
+  out_path: "tmp/test-output"
+>
+args: <
+  in_hash: "5450a4acb852ff4521aed7ee121c41e4e7388828714f93623807f12b14e3e4cc"
+>
+args: <
+  in_hash: "2590532ed6ac4e4552dc68b26cfe7888480d185a8bf7152c92bb6f0f20571ea5"
+>

--- a/test/testdata/testgenrconfig2.textproto
+++ b/test/testdata/testgenrconfig2.textproto
@@ -3,7 +3,7 @@ args: <
   str_arg: "-cf"
 >
 args: <
-  out_path: "tmp/output"
+  out_content: "OUTPUT"
 >
 args: <
   in_hash: "5450a4acb852ff4521aed7ee121c41e4e7388828714f93623807f12b14e3e4cc"


### PR DESCRIPTION
Add function that generates a Protocol Buffer configuration file from command line arguments.
This function allows to easily create a configuration file from the expected command line arguments. The type of each argument needs to be added before the argument.
We also add tests for this function.