### PR TITLE
Move functions out of main

### DIFF
--- a/cmd/genrconfig/genrconfig.go
+++ b/cmd/genrconfig/genrconfig.go
@@ -31,7 +31,7 @@ import (
  * The second argudment is the name of the binary and the arguments follow.
  * The arguments must have as a prefix "type:". The type can be: strarg, infile, outpath, outcontent.
  */
-func main() {
+func GenerateConfig() {
   if len(os.Args) < 2 {
     log.Fatal("Expected the name of the binary.")
   }
@@ -53,4 +53,8 @@ func main() {
   if _, err := fmt.Print((proto.MarshalTextString(&mc))); err != nil {
       log.Fatal(err)
   }
+}
+
+func main() {
+  GenerateConfig()
 }

--- a/cmd/mockexec/mockexec.go
+++ b/cmd/mockexec/mockexec.go
@@ -31,8 +31,8 @@ import (
 
 const bufferSize = 4096
 
-func main() {
-	if len(os.Args) < 2 {
+func MockExecutable() {
+  if len(os.Args) < 2 {
 		log.Fatal("Expected the path of the configuration file")
 	}
 	t, err := ioutil.ReadFile(os.Args[1])
@@ -119,4 +119,8 @@ func main() {
 			log.Fatal(err)
 		}
 	}
+}
+
+func main() {
+	MockExecutable()
 }


### PR DESCRIPTION
Move functions out of main so they can be called without the need of running the binary.